### PR TITLE
fix: support `—moduleResolution node16` in `compute-scroll-into-view`

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,19 +24,20 @@
   "license": "MIT",
   "author": "Cody Olsen",
   "sideEffects": false,
-  "type": "module",
+  "type": "commonjs",
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
       "source": "./src/index.ts",
-      "import": "./dist/index.js",
-      "require": "./dist/index.cjs",
+      "require": "./dist/index.js",
+      "import": "./dist/index.mjs",
       "default": "./dist/index.js"
     },
     "./package.json": "./package.json"
   },
-  "main": "./dist/index.cjs",
-  "module": "./dist/index.js",
+  "source": "./src/index.ts",
+  "main": "./dist/index.js",
+  "module": "./dist/index.mjs",
   "typings": "./dist/index.d.ts",
   "files": [
     "dist",

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "singleQuote": true
   },
   "dependencies": {
-    "compute-scroll-into-view": "^3.0.0"
+    "compute-scroll-into-view": "^3.0.1"
   },
   "devDependencies": {
     "@sanity/pkg-utils": "^2.2.5",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,6 +13,7 @@
     "skipLibCheck": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,
+    "esModuleInterop": true,
     "strict": true,
     "lib": ["dom", "dom.iterable", "esnext"]
   },


### PR DESCRIPTION
i tested it locally(needed fix in compute-scroll-into-view too)